### PR TITLE
Type refactor & support for declared actions

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -44,13 +44,13 @@ handleParse = either error C.runSchedule
 run :: Session -> Schedule -> (IO a) -> IO [a]
 run (Within _ (Just n) _) t = C.times n t
 run (Within _ Nothing _) t  = C.times 1 t
-run (Randomly _ ma _) t     = C.timesIn ma t
+run (Randomly _ ma _) t     = C.times ma t
 run _ t                     = C.times 1 t
 
 toSchedule :: Session -> UTCTime -> C.Schedule
-toSchedule (Within ms _ _) _ = C.Offset ms
+toSchedule (Within ms _ _) _   = C.Offset ms
 toSchedule (Randomly ms _ _) _ = C.Offset ms
-toSchedule (Between s e _) t = C.Window (addUTCTime (nomTime (fromMaybe 0 s)) t) (addUTCTime (nomTime e) t)
+toSchedule (Between s e _) t   = undefined -- C.Window (addUTCTime (nomTime (fromMaybe 0 s)) t) (addUTCTime (nomTime e) t)
 
 nomTime :: Int -> NominalDiffTime
 nomTime b = realToFrac secs

--- a/bnf.md
+++ b/bnf.md
@@ -4,8 +4,8 @@ This tool defines the following grammar with respect to its file-based support.
     <freq-modifier> ::= "randomly" | "exponentially" | "every" | "in"
     <cause-spec> ::= <spatial-spec> | <temporal-spec>
     <spatial-spec> ::= "TBD"
-    <temporal-spec> ::= "between" <integer> <integer> <time-unit>
-                      | "offset" <integer> <time-unit>
+    <temporal-spec> ::= <integer> <integer> <time-unit>
+                      | <integer> <time-unit>
     <time-unit> ::= "seconds" | "minutes" | "hours" | "days"
     <opt-body> ::= <shell-command>
                  | ":" <plain-text>

--- a/examples/invalid/action-declared.chaos
+++ b/examples/invalid/action-declared.chaos
@@ -1,0 +1,7 @@
+action date {
+  date > date.now
+  sleep 2
+  date >> date.now
+}
+
+in 2 seconds NonExistentAction

--- a/examples/valid/action-declared.chaos
+++ b/examples/valid/action-declared.chaos
@@ -1,0 +1,6 @@
+action date {
+  date > date.now
+  sleep 2
+  date >> date.now
+}
+in 2 seconds date

--- a/src/Data/Time/Schedule/Chaos.hs
+++ b/src/Data/Time/Schedule/Chaos.hs
@@ -106,7 +106,7 @@ genTime (Window s e) rg = return $ randomTimeBetween s e rg
 
 -- | Shorthand for the difference between two UTCTime instances
 diff :: UTCTime -> UTCTime -> NominalDiffTime
-diff st en = diffUTCTime st en
+diff = diffUTCTime
 
 -- | Delay for a random amount within the schedule
 delayFor :: RandomGen g => Schedule -> g -> IO g

--- a/src/Data/Time/Schedule/Chaos.hs
+++ b/src/Data/Time/Schedule/Chaos.hs
@@ -7,30 +7,24 @@
 module Data.Time.Schedule.Chaos
   (
     -- | Typeclasses
-    Frequency (..),
     Cause (..),
 
     -- | Data constructors
     Schedule (..),
 
     -- | Functions
-    asyncTimesIn,
     genTime,
-    genWindow,
     mkOffsets,
     mkSchedules,
-    timesIn,
-    times,
     randomSeconds,
     randomTimeBetween,
     runSchedule,
-    runSchedules,
     mergeAndRunSchedules
     ) where
 
 import           Control.Concurrent       (threadDelay)
 import           Control.Concurrent.Async (Async (..), async)
-import           Control.Monad            (liftM, replicateM)
+import           Control.Monad            (replicateM)
 import           Control.Monad.IO.Class   (MonadIO, liftIO)
 import           Control.Monad.Reader     (Reader, runReader)
 import           Data.Bifunctor           (first)
@@ -43,29 +37,57 @@ import           System.Random            (Random (..), RandomGen, newStdGen,
 
 -- | An event source descriptor based on time
 data Schedule =
-  -- | An point in the future
+  -- | A point in the future, in ms
   Offset Int
-  -- | Perform something within the start and end times
+  -- | A point in the future, as a @UTCTime@
+  | Instant UTCTime
+  -- | A point between a lower & upper time boundary
   | Window UTCTime UTCTime
   deriving (Read, Show, Eq, Generic)
 
 -- | Operations for sourcing events
-class (MonadIO m) => Cause m a where
-  -- | Request the next event, where @a@ is the even source descriptor,
+class (MonadIO m) => Cause m s where
+
+  -- | Request the next event, where @s@ is the event source descriptor,
   -- and @m b@ is the event generation action
-  next :: a -> m b -> m b
+  next :: s -> m b -> m b
 
--- | Operations pertaining to the rate of an event occurring
-class (MonadIO m, Cause m a) => Frequency m a where
-  -- | Given the
-  hasMore :: a -> m Bool
+  -- | Invoke @next@ @Int@ times
+  times :: Int -> s -> m b -> m [b]
+  times n s a = replicateM n (next s a)
 
+  -- | Generate events according to @s@ at most @[1, n]@ times, using the
+  -- supplied random generator
+  atMost :: RandomGen g => Int -> s -> m b -> g -> m (g, [b])
+  atMost n s a g = return (randomR (1, n) g) >>= (\(n', g') -> do
+    v <- times n' s a
+    return (g', v))
+
+  -- | Generate an event, using @s@ as the *lower* bound
+  lower :: s -> m b -> m b
+
+  -- | Generate an event, using @s@ as the *upper* bound
+  upper :: s -> m b -> m b
+
+instance Cause IO Int where
+  -- | A delay of @ms@ milliseconds before executing @a@
+  next ms a  = threadDelay (ms * 1000) >> a
+
+instance Cause IO UTCTime where
+  -- | A delay of @t - getCurrentTime@  before executing @a@
+  next t a = getCurrentTime >>= return . timeDiffSecs >>= (\t' -> next t' a)
+    where timeDiffSecs :: UTCTime -> Int
+          timeDiffSecs = round . flip diffUTCTime t
+
+-- | Generate events, parameterised by time
 instance Cause IO Schedule where
-  next = delayRun
+
+  next (Offset ms) a  = next ms a
+  --next (Window s e) a = newStdGen >>= return . randomTimeBetween s e
 
 -- | Asynchronous convenience wrapper for @timesIn@
-asyncTimesIn :: Int -> Schedule -> IO a -> IO [Async a]
-asyncTimesIn n s a = timesIn n s (async a)
+--asyncTimesIn :: Int -> Schedule -> IO a -> IO [Async a]
+--asyncTimesIn n s a = timesIn n s (async a)
 
 -- | Randomly pick a time compatible with the given schedule
 genTime :: (MonadIO m, RandomGen g) => Schedule -> g -> m (UTCTime, g)
@@ -82,17 +104,11 @@ diff st en = diffUTCTime st en
 -- | Delay for a random amount within the schedule
 delayFor :: RandomGen g => Schedule -> g -> IO g
 delayFor sc g = do
-    (ti, g') <- genTime sc g
-    del <- case sc of
-                Window s _ -> return $ getDelay s ti
-                Offset _   -> getCurrentTime >>= return . flip getDelay ti
-    threadDelay del
-    return g'
-
--- | Delay exactly as the schedule suggests, then run the action
-delayRun :: Schedule -> IO a -> IO a
-delayRun (Offset ms) a = threadDelay (ms * 1000) >> a
-delayRun s _           = error $ "Not yet supported: " ++ show s
+  let (ti, g') = undefined -- <- genTime sc g
+  del <- case sc of
+              Offset _   -> getCurrentTime >>= return . flip getDelay ti
+  threadDelay del
+  return g'
 
 -- | Turn the @UTCTime@ to its microseconds
 getDelay :: UTCTime -> UTCTime -> Int
@@ -100,10 +116,6 @@ getDelay s t = delay
   where tDiff = (round $ diff s t) :: Int
         micros = 1000 * 1000
         delay = abs $ tDiff * micros
-
--- | Run the action any amount of times in the interval @[1, i]@, using a supplied RandomGen
-genWindow :: RandomGen g => Int -> Schedule -> IO a -> g -> IO [a]
-genWindow i s a g = return (randomR (1, i) g) >>= return . fst >>= (\n -> times n s a) -- heh
 
 -- | Construct an infinite list of constant @Offset@ instances
 mkOffsets :: Int -> [Schedule]
@@ -127,7 +139,7 @@ runTarget :: (RandomGen g, MonadIO m) => Schedule -> IO a -> g -> m a
 runTarget sc a g = liftIO $ delayFor sc g >> a
 
 runSchedule :: (Schedule, IO a) -> IO a
-runSchedule (sc, a) = delayRun sc a
+runSchedule (sc, a) = next sc a
 
 -- | Run the specified action-schedule pairs
 runSchedules :: [(Schedule, IO a)] -> IO [a]
@@ -139,12 +151,3 @@ mergeAndRunSchedules x y = runSchedules $ toPairs x y
   where toPairs (x':xs) (y':ys) = (x', y') : toPairs xs ys
         toPairs [] _            = []
         toPairs _ []            = []
-
--- | Schedule the action @n@ times
-times :: Int -> Schedule -> IO a -> IO [a]
-times n sch a = liftIO $ replicateM n work
-  where work = newStdGen >>= runTarget sch a
-
--- | Run the action any amount of times in the interval @[1, n]@
-timesIn :: Int -> Schedule -> IO a -> IO [a]
-timesIn n s a = newStdGen >>= genWindow n s a

--- a/src/Data/Time/Schedule/Chaos.hs
+++ b/src/Data/Time/Schedule/Chaos.hs
@@ -48,7 +48,7 @@ data Schedule =
 -- | Operations covering the source of an event
 class (MonadIO m) => Cause m a where
   -- | Request the next value, where @a@ is the even source type
-  next :: RandomGen g => a -> m b -> g -> m b
+  next :: a -> m b -> m b
 
 -- | Operations pertaining to the rate of an event occurring
 class (MonadIO m, Cause m a) => Frequency m a where
@@ -56,7 +56,7 @@ class (MonadIO m, Cause m a) => Frequency m a where
   hasMore :: a -> m Bool
 
 instance Cause IO Schedule where
-  next s ac g = runTarget s ac g
+  next s ac = newStdGen >>= runTarget s ac
 
 -- | Asynchronous convenience wrapper for @timesIn@
 asyncTimesIn :: Int -> Schedule -> IO a -> IO [Async a]

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,4 @@ local-bin-path: .
 packages:
 - .
 extra-deps: []
-resolver: nightly-2018-10-13
+resolver: nightly-2018-11-02

--- a/test/Data/Time/Schedule/Chaos/ParserSpec.hs
+++ b/test/Data/Time/Schedule/Chaos/ParserSpec.hs
@@ -4,7 +4,6 @@
 
 module Data.Time.Schedule.Chaos.ParserSpec ( spec ) where
 
-import           Control.Monad                   (forM_)
 import qualified Data.ByteString                 as B
 import           Data.ByteString.Char8           (pack)
 import           Data.Char                       (toLower)
@@ -36,7 +35,6 @@ spec =
               ex2 = pack $ "in " ++ show i ++ " " ++ lc u ++ " : hello there!"
           parserTest ex1 i u
           parserTest ex2 i u)
-
 
 lc :: TimeUnit -> String
 lc = map toLower . show

--- a/test/Data/Time/Schedule/ChaosSpec.hs
+++ b/test/Data/Time/Schedule/ChaosSpec.hs
@@ -59,6 +59,10 @@ spec = do
 
     prop "Simple reader example" prop_mkSchedule_example
 
+    context "Cause supports Schedule" $ do
+      runIO $ print "lol"
+
+
 prop_mkSchedule_example :: ExampleEnv -> [IO String] -> Expectation
 prop_mkSchedule_example ex l = do
   let res = mkSchedules reader ex l

--- a/test/Data/Time/Schedule/ExamplesSpec.hs
+++ b/test/Data/Time/Schedule/ExamplesSpec.hs
@@ -42,4 +42,6 @@ runTest :: FilePath -> ValidationFunction -> Expectation
 runTest p f = do
   exs <- getExamples p
   length exs `shouldNotBe` 0
-  forM_ exs (f . parseTargets)
+  forM_ exs (\ex -> do
+    print $ "Testing: " ++ show ex
+    f $ parseTargets ex)

--- a/test/Data/Time/Schedule/ExamplesSpec.hs
+++ b/test/Data/Time/Schedule/ExamplesSpec.hs
@@ -2,7 +2,7 @@
 {-# OPTIONS_GHC -Wall #-}
 
 module Data.Time.Schedule.ExamplesSpec ( spec ) where
-import           Control.Monad                   (filterM, forM_, mapM, mapM_)
+import           Control.Monad                   (filterM, forM_, mapM)
 import qualified Data.ByteString.Char8           as BS
 import           Data.List
 import           Data.Time.Schedule.Chaos        (Schedule (..))
@@ -13,9 +13,6 @@ import           Test.Hspec
 type Target = (Schedule, IO ())
 
 type ValidationFunction = (Either String Target) -> Expectation
-
-instance Show (IO a) where
-  show a = "IO a"
 
 spec :: Spec
 spec = do
@@ -45,5 +42,4 @@ runTest :: FilePath -> ValidationFunction -> Expectation
 runTest p f = do
   exs <- getExamples p
   length exs `shouldNotBe` 0
-  mapM_ (print . (++) "Example: " . show) exs
   forM_ exs (f . parseTargets)

--- a/test/Data/Time/Schedule/ExamplesSpec.hs
+++ b/test/Data/Time/Schedule/ExamplesSpec.hs
@@ -20,8 +20,7 @@ spec = do
     it "Supports valid examples" $
       runTest "./examples/valid" validParseTest
     it "Rejects invalid examples" $ do
-      v <- runTest "examples/invalid" invalidParseTest
-      return v
+      runTest "examples/invalid" invalidParseTest
 
 getExamples :: FilePath -> IO [BS.ByteString]
 getExamples p = getDirectoryContents p


### PR DESCRIPTION
Adds support  for declared actions:

    action Name {
      # Do some shell stuff
    }

which can then be reference in the schedule statement:

`every 60 seconds Action1, actionTwo, blah`

Adds the `Cause` typeclass, which may or may not be used.